### PR TITLE
check if /etc/doas.conf exists

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-
 if [ $(id -u) -ne 0 ] ; then
     echo "You need to bootstrap the system as root or do the steps manually"
     exit 1
@@ -12,7 +11,7 @@ echo "   /etc/installurl:\n   The default package url is going to be changed to 
 echo "   /etc/doas.conf:\n   We will permit all member of :wheel to doas without password, change this afterwards"
 
 echo "We will back them up"
-cp -v /etc/doas.conf /etc/doas.conf.bak.$(date +%F_%R)
+[[ -f /etc/doas.conf ]] || cp -v /etc/doas.conf /etc/doas.conf.bak.$(date +%F_%R)
 cp -v /etc/installurl /etc/installurl.bak.$(date +%F_%R)
 
 echo "Now we change them to the standard configuration and add the needed ansible package"


### PR DESCRIPTION
By default, after a fresh install, there's no /etc/doas.conf, except in /etc/examples