### PR TITLE
Avoid sysadmin to restart manually these services

### DIFF
--- a/roles/pre-ansimail/files/ansimail_scripts/virtual-regen
+++ b/roles/pre-ansimail/files/ansimail_scripts/virtual-regen
@@ -37,3 +37,6 @@ chown root:_smtpd /etc/mail/virtual /etc/mail/revirt
 cp $user_home/passwd /etc/mail/passwd
 chmod 440 /etc/mail/passwd
 chown _smtpd:_dovecot /etc/mail/passwd
+
+# Restart services
+/usr/sbin/rcctl restart smtpd dovecot


### PR DESCRIPTION
I saw in your Wiki, a lot of `rcctl restart smtpd dovecot` after a `ansimail virtual-regen`.
Add the restart in the script make more sense.