### PR TITLE
vdomains-file-perms

### DIFF
--- a/roles/smtpd/defaults/main.yml
+++ b/roles/smtpd/defaults/main.yml
@@ -17,7 +17,7 @@ smtpd_tables:
   - {name: "mailname", user: "root", group: "wheel", perm: "0640"}
   - {name: "virtual", user: "root", group: "_smtpd", perm: "0640"}
   - {name: "revirt", user: "root", group: "_smtpd", perm: "0640"}
-  - {name: "vdomains", user: "root", group: "wheel", perm: "0640"}
+  - {name: "vdomains", user: "root", group: "wheel", perm: "0644"}
   - {name: "passwd", user: "_smtpd", group: "_dovecot", perm: "0440"}
 
 smtpd_legacy_protocols: false


### PR DESCRIPTION
Set correct permissions for file `/etc/mail/vdomains`
* Role `smtpd` failed with `0640` at task `ensure gpg files are created`
  when running the command `excision ensure-gpg`, since it tries opening
  this file as user `excision` (which is not in group `wheel`)

Or, to be more precise, this part of `/usr/local/lib/excision/ensure-gpg` fails to run:
```
# now do the bulk of the init using the excision account
su -l excision -c "sh /var/excision-home/excision-wks-init"
```