### PR TITLE
Check if 'pf_private_interfaces' variable is set

### DIFF
--- a/roles/smtpd/templates/smtpd.conf.j2
+++ b/roles/smtpd/templates/smtpd.conf.j2
@@ -59,12 +59,14 @@ listen on socket \
 	filter rspamd
 #
 # Private interfaces
+{% if pf_private_interfaces is defined %}
 {% for pif in pf_private_interfaces %}
 listen on {{ pif }}
 listen on {{ pif }} \
 	tag trusted-interface \
 	filter rspamd
 {% endfor %}
+{% endif %}
 #
 # Incoming messages from outside to people in <vdomain>
 # this filter checks for spam vs ham on smtp port


### PR DESCRIPTION
Check if 'pf_private_interfaces' variable is set. Otherwise the `site-install.yml` playbook fails at creating the smtpd config, since it does not include the `pf` role and therefore doesn't know the `pf_private_interfaces` variable.