### PR TITLE
enable sieve's vacation-seconds extension

### DIFF
--- a/roles/dovecot/templates/90-sieve.conf.j2
+++ b/roles/dovecot/templates/90-sieve.conf.j2
@@ -92,7 +92,11 @@ plugin {
   # to the default. For example `sieve_extensions = +imapflags' will enable the
   # deprecated imapflags extension in addition to all extensions were already
   # enabled by default.
-  sieve_extensions = +spamtest +spamtestplus +virustest +notify +imapflags # (default: +notify +imapflags)
+  sieve_extensions = +spamtest +spamtestplus +virustest +notify +imapflags +vacation-seconds # (default: +notify +imapflags)
+
+  sieve_vacation_min_period = 30m
+  sieve_vacation_default_period = 5d
+  sieve_vacation_max_period = 30d
 
   # Spamtest and Virustest
   # https://wiki.dovecot.org/Pigeonhole/Sieve/Extensions/SpamtestVirustest


### PR DESCRIPTION
This can be useful for some automation