### PR TITLE
Intermittent fix for acme-client (excision renew-certs) failure

### DIFF
--- a/extrapolate.yml
+++ b/extrapolate.yml
@@ -1,6 +1,4 @@
 ---
-subdomains: "{{ [ mail_subdomain ] + required_subdomains + extra_subdomains }}"
-
 hostname: "{{ mail_subdomain }}.{{ domains[0].name }}"
 
 enable_dns: "{{ domains | map(attribute='dns', default=False) is any}}"

--- a/roles/zones/templates/domain.zone.j2
+++ b/roles/zones/templates/domain.zone.j2
@@ -52,7 +52,7 @@ $ORIGIN	{{ item.name }}.
 ; gives an extra layer of encryption
 ;; strict transport security
 ; somewhat like DANE but doesn't need DNSSEC
-{% for sdomain in subdomains %}
+{% for sdomain in {{ [ mail_subdomain ] + required_subdomains + extra_subdomains }} %}
 {% if ipv4 is defined %}
 {{ sdomain }}	IN	A	{{ ipv4 }}
 {% endif %}


### PR DESCRIPTION
to merge or not to merge...

Intermittent fix for acme-client (excision renew-certs) failure
* Temporary fix until 'zones' role gets refactored (planned by
  epsilon-0)
* Problem: 'acme-client' re-issues an existing certificate with each
  invocation, although a cert exists already with correct common
  name and subject alt names.
  * It should instead skip re-issuing/renewing if validity > 30 days.
  * This is caused by providing the certificate common name as part of
    the 'alternative names' in '/etc/excision/ssl/acme-client.conf',
    which let's 'acme-client' assume there was a change of domains
    listed.
* Variable 'subdomains' is only used in the 'acme' and 'zones' role
  * ...so I removed it from 'extrapolate.yml', making the variable
    definition in 'defaults.yml' effective.
  * The template in role 'zones' will still be fed with the correct list
    of domain names, and 'acme-client.conf' template in role 'acme' will
    get rid of the surplus common name in 'alternative names' setting.